### PR TITLE
Faster noise

### DIFF
--- a/filmgrainer/filmgrainer.py
+++ b/filmgrainer/filmgrainer.py
@@ -39,11 +39,11 @@ def _getGrainMask(img_width:int, img_height:int, saturation:float, grayscale:boo
     filename = MASK_CACHE_PATH + "grain-%d-%d-%s-%s-%s-%d.png" % (
         img_width, img_height, str_sat, str(grain_size), str(grain_gauss), seed)
     if os.path.isfile(filename):
-        print("Reusing: %s" % filename)
+        # print("Reusing: %s" % filename)
         mask = Image.open(filename)
     else:
         mask = graingen.grainGen(img_width, img_height, grain_size, grain_gauss, sat, seed)
-        print("Saving: %s" % filename)
+        # print("Saving: %s" % filename)
         if not os.path.isdir(MASK_CACHE_PATH):
             os.mkdir(MASK_CACHE_PATH)
         mask.save(filename, format="png", compress_level=1)
@@ -60,19 +60,19 @@ def process(image, scale:float, src_gamma:float, grain_power:float, shadows:floa
     org_height = img.size[1]
     
     if scale != 1.0:
-        print("Scaling source image ...")
+        # print("Scaling source image ...")
         img = img.resize((int(org_width / scale), int(org_height / scale)),
                           resample = Image.LANCZOS)
     
     img_width = img.size[0]
     img_height = img.size[1]
-    print("Size: %d x %d" % (img_width, img_height))
+    # print("Size: %d x %d" % (img_width, img_height))
 
-    print("Calculating map ...")
+    # print("Calculating map ...")
     map = graingamma.Map.calculate(src_gamma, grain_power, shadows, highs)
     # map.saveToFile("map.png")
 
-    print("Calculating grain stock ...")
+    # print("Calculating grain stock ...")
     (grain_size, grain_gauss) = _grainTypes(grain_type)
     mask = _getGrainMask(img_width, img_height, grain_sat, gray_scale, grain_size, grain_gauss, seed)
 
@@ -83,7 +83,7 @@ def process(image, scale:float, src_gamma:float, grain_power:float, shadows:floa
     lookup = map.map
 
     if gray_scale:
-        print("Film graining image ... (grayscale)")
+        # print("Film graining image ... (grayscale)")
         for y in range(0, img_height):
             for x in range(0, img_width):
                 m = mask_pixels[x, y]
@@ -93,7 +93,7 @@ def process(image, scale:float, src_gamma:float, grain_power:float, shadows:floa
                 gray_lookup = lookup[gray, m]
                 img_pixels[x, y] = (gray_lookup, gray_lookup, gray_lookup)
     else:
-        print("Film graining image ...")
+        # print("Film graining image ...")
         for y in range(0, img_height):
             for x in range(0, img_width):
                 (mr, mg, mb) = mask_pixels[x, y]
@@ -104,11 +104,11 @@ def process(image, scale:float, src_gamma:float, grain_power:float, shadows:floa
                 img_pixels[x, y] = (r, g, b)
     
     if scale != 1.0:
-        print("Scaling image back to original size ...")
+        # print("Scaling image back to original size ...")
         img = img.resize((org_width, org_height), resample = Image.LANCZOS)
     
     if sharpen > 0:
-        print("Sharpening image: %d pass ..." % sharpen)
+        # print("Sharpening image: %d pass ..." % sharpen)
         for x in range(sharpen):
             img = img.filter(ImageFilter.SHARPEN)
 

--- a/filmgrainer/graingen.py
+++ b/filmgrainer/graingen.py
@@ -1,28 +1,53 @@
 from PIL import Image
 import random
 import numpy as np
+import pyfastnoisesimd as fns
+import warnings
 
-def _makeGrayNoise(width, height, power):
-    buffer = np.zeros([height, width], dtype=int)
+# Suppress specific deprecation warnings
+warnings.filterwarnings("ignore", message=".*`product` is deprecated.*")
 
-    for y in range(0, height):
-        for x in range(0, width):
-            buffer[y, x] = random.gauss(128, power)
-    buffer = buffer.clip(0, 255)
-    return Image.fromarray(buffer.astype(dtype=np.uint8))
+def _makeGrayNoise(width, height, power, seed=0):
+    # Setup noise type and parameters
+    noise = fns.Noise(seed=seed)
+    noise.noise_type = fns.NoiseType.Perlin
+    noise.frequency = 1.0  # Adjust frequency for different scales of noise
 
-def _makeRgbNoise(width, height, power, saturation):
-    buffer = np.zeros([height, width, 3], dtype=int)
-    intens_power = power * (1.0 - saturation)
-    for y in range(0, height):
-        for x in range(0, width):
-            intens = random.gauss(128, intens_power)
-            buffer[y, x, 0] = random.gauss(0, power) * saturation + intens
-            buffer[y, x, 1] = random.gauss(0, power) * saturation + intens
-            buffer[y, x, 2] = random.gauss(0, power) * saturation + intens
+    # Generate noise
+    buffer = noise.genAsGrid(shape=(height, width))
 
-    buffer = buffer.clip(0, 255)
-    return Image.fromarray(buffer.astype(dtype=np.uint8))
+    # Scale noise by power before normalization
+    buffer *= power
+
+    # Normalize and scale to 0-255 range
+    buffer = (buffer - buffer.min()) / (buffer.max() - buffer.min()) * 255
+    return Image.fromarray(buffer.astype(np.uint8))
+
+
+def _makeRgbNoise(width, height, power, saturation=0.5, seed=0):
+    # Setup noise type and parameters
+    noise = fns.Noise(seed=seed)
+    noise.noise_type = fns.NoiseType.Perlin
+    noise.frequency = 1.0  # Adjust frequency for different scales of noise
+    
+    # Initialize RGB buffer
+    rgb_buffer = np.zeros((height, width, 3), dtype=np.float32)
+
+    # Generate base intensity noise and scale by power
+    intens_buffer = noise.genAsGrid(shape=(height, width)) * power
+
+    # Normalize intensity noise
+    intens_buffer = (intens_buffer - intens_buffer.min()) / (intens_buffer.max() - intens_buffer.min()) * 255
+    
+    for i in range(3):
+        noise.seed += 1  # Change seed for each channel to get different noise
+        color_buffer = noise.genAsGrid(shape=(height, width)) * power
+        color_buffer = (color_buffer - color_buffer.min()) / (color_buffer.max() - color_buffer.min()) * 255
+        # Blend intensity and color noise based on saturation
+        rgb_buffer[..., i] = intens_buffer * (1 - saturation) + color_buffer * saturation
+
+    rgb_buffer = np.clip(rgb_buffer, 0, 255)  # Ensure values are in byte range
+    return Image.fromarray(rgb_buffer.astype(np.uint8))
 
 
 def grainGen(width, height, grain_size, power, saturation, seed = 1):
@@ -33,13 +58,13 @@ def grainGen(width, height, grain_size, power, saturation, seed = 1):
     random.seed(seed)
 
     if saturation < 0.0:
-        print("Making B/W grain, width: %d, height: %d, grain-size: %s, power: %s, seed: %d" % (
-            noise_width, noise_height, str(grain_size), str(power), seed))
-        img = _makeGrayNoise(noise_width, noise_height, power)
+        # print("Making B/W grain, width: %d, height: %d, grain-size: %s, power: %s, seed: %d" % (
+            # noise_width, noise_height, str(grain_size), str(power), seed))
+        img = _makeGrayNoise(noise_width, noise_height, power, seed)
     else:
-        print("Making RGB grain, width: %d, height: %d, saturation: %s, grain-size: %s, power: %s, seed: %d" % (
-            noise_width, noise_height, str(saturation), str(grain_size), str(power), seed))
-        img = _makeRgbNoise(noise_width, noise_height, power, saturation)
+        # print("Making RGB grain, width: %d, height: %d, saturation: %s, grain-size: %s, power: %s, seed: %d" % (
+            # noise_width, noise_height, str(saturation), str(grain_size), str(power), seed))
+        img = _makeRgbNoise(noise_width, noise_height, power, saturation, seed)
 
     # Resample
     if grain_size != 1.0:
@@ -50,6 +75,8 @@ def grainGen(width, height, grain_size, power, saturation, seed = 1):
 
 if __name__ == "__main__":
     import sys
+    import time  # Import the time module
+
     if len(sys.argv) == 8:
         width = int(sys.argv[2])
         height = int(sys.argv[3])
@@ -57,5 +84,16 @@ if __name__ == "__main__":
         power = float(sys.argv[5])
         sat = float(sys.argv[6])
         seed = int(sys.argv[7])
+
+        start_time = time.time()  # Start timing
+
+        # Generate the noise image
         out = grainGen(width, height, grain_size, power, sat, seed)
+
+        # Save the generated image
         out.save(sys.argv[1])
+
+        end_time = time.time()  # End timing
+        elapsed_time = end_time - start_time  # Calculate elapsed time
+
+        print(f"Image generated and saved in {elapsed_time} seconds.")  # Print out the elapsed time

--- a/filmgrainer/graingen.py
+++ b/filmgrainer/graingen.py
@@ -7,17 +7,40 @@ import warnings
 # Suppress specific deprecation warnings
 warnings.filterwarnings("ignore", message=".*`product` is deprecated.*")
 
+def pad_dimensions_to_simd(width, height, simd_width=16):
+    """
+    Pad the dimensions to be divisible by a given SIMD width.
+
+    Parameters:
+    - width: The original width of the image.
+    - height: The original height of the image.
+    - simd_width: The SIMD width to pad dimensions to (default 16).
+
+    Returns:
+    - padded_width: The padded width.
+    - padded_height: The padded height.
+    """
+    padded_width = ((width + simd_width - 1) // simd_width) * simd_width
+    padded_height = ((height + simd_width - 1) // simd_width) * simd_width
+    return padded_width, padded_height
+
 def _makeGrayNoise(width, height, power, seed=0):
+    # Pad dimensions for SIMD compatibility
+    padded_width, padded_height = pad_dimensions_to_simd(width, height)
+
     # Setup noise type and parameters
     noise = fns.Noise(seed=seed)
     noise.noise_type = fns.NoiseType.Perlin
     noise.frequency = 1.0  # Adjust frequency for different scales of noise
 
-    # Generate noise
-    buffer = noise.genAsGrid(shape=(height, width))
+    # Generate noise with padded dimensions
+    padded_buffer = noise.genAsGrid(shape=(padded_height, padded_width))
 
     # Scale noise by power before normalization
-    buffer *= power
+    padded_buffer *= power
+
+    # Crop the padded buffer to the original dimensions if necessary
+    buffer = padded_buffer[:height, :width]
 
     # Normalize and scale to 0-255 range
     buffer = (buffer - buffer.min()) / (buffer.max() - buffer.min()) * 255
@@ -25,26 +48,32 @@ def _makeGrayNoise(width, height, power, seed=0):
 
 
 def _makeRgbNoise(width, height, power, saturation=0.5, seed=0):
+    # Pad dimensions for SIMD compatibility
+    padded_width, padded_height = pad_dimensions_to_simd(width, height)
+
     # Setup noise type and parameters
     noise = fns.Noise(seed=seed)
     noise.noise_type = fns.NoiseType.Perlin
     noise.frequency = 1.0  # Adjust frequency for different scales of noise
     
-    # Initialize RGB buffer
-    rgb_buffer = np.zeros((height, width, 3), dtype=np.float32)
+    # Initialize padded RGB buffer
+    padded_rgb_buffer = np.zeros((padded_height, padded_width, 3), dtype=np.float32)
 
-    # Generate base intensity noise and scale by power
-    intens_buffer = noise.genAsGrid(shape=(height, width)) * power
+    # Generate base intensity noise with padded dimensions and scale by power
+    padded_intens_buffer = noise.genAsGrid(shape=(padded_height, padded_width)) * power
 
-    # Normalize intensity noise
-    intens_buffer = (intens_buffer - intens_buffer.min()) / (intens_buffer.max() - intens_buffer.min()) * 255
+    # Normalize padded intensity noise
+    padded_intens_buffer = (padded_intens_buffer - padded_intens_buffer.min()) / (padded_intens_buffer.max() - padded_intens_buffer.min()) * 255
     
     for i in range(3):
         noise.seed += 1  # Change seed for each channel to get different noise
-        color_buffer = noise.genAsGrid(shape=(height, width)) * power
-        color_buffer = (color_buffer - color_buffer.min()) / (color_buffer.max() - color_buffer.min()) * 255
+        padded_color_buffer = noise.genAsGrid(shape=(padded_height, padded_width)) * power
+        padded_color_buffer = (padded_color_buffer - padded_color_buffer.min()) / (padded_color_buffer.max() - padded_color_buffer.min()) * 255
         # Blend intensity and color noise based on saturation
-        rgb_buffer[..., i] = intens_buffer * (1 - saturation) + color_buffer * saturation
+        padded_rgb_buffer[..., i] = padded_intens_buffer * (1 - saturation) + padded_color_buffer * saturation
+
+    # Crop the padded RGB buffer to the original dimensions
+    rgb_buffer = padded_rgb_buffer[:height, :width, :]
 
     rgb_buffer = np.clip(rgb_buffer, 0, 255)  # Ensure values are in byte range
     return Image.fromarray(rgb_buffer.astype(np.uint8))

--- a/filmgrainer/graingen.py
+++ b/filmgrainer/graingen.py
@@ -87,12 +87,12 @@ def grainGen(width, height, grain_size, power, saturation, seed = 1):
     random.seed(seed)
 
     if saturation < 0.0:
-        print("Making B/W grain, width: %d, height: %d, grain-size: %s, power: %s, seed: %d" % (
-            noise_width, noise_height, str(grain_size), str(power), seed))
+        # print("Making B/W grain, width: %d, height: %d, grain-size: %s, power: %s, seed: %d" % (
+        #     noise_width, noise_height, str(grain_size), str(power), seed))
         img = _makeGrayNoise(noise_width, noise_height, power, seed)
     else:
-        print("Making RGB grain, width: %d, height: %d, saturation: %s, grain-size: %s, power: %s, seed: %d" % (
-            noise_width, noise_height, str(saturation), str(grain_size), str(power), seed))
+        # print("Making RGB grain, width: %d, height: %d, saturation: %s, grain-size: %s, power: %s, seed: %d" % (
+        #     noise_width, noise_height, str(saturation), str(grain_size), str(power), seed))
         img = _makeRgbNoise(noise_width, noise_height, power, saturation, seed)
 
     # Resample

--- a/filmgrainer/graingen.py
+++ b/filmgrainer/graingen.py
@@ -58,12 +58,12 @@ def grainGen(width, height, grain_size, power, saturation, seed = 1):
     random.seed(seed)
 
     if saturation < 0.0:
-        # print("Making B/W grain, width: %d, height: %d, grain-size: %s, power: %s, seed: %d" % (
-            # noise_width, noise_height, str(grain_size), str(power), seed))
+        print("Making B/W grain, width: %d, height: %d, grain-size: %s, power: %s, seed: %d" % (
+            noise_width, noise_height, str(grain_size), str(power), seed))
         img = _makeGrayNoise(noise_width, noise_height, power, seed)
     else:
-        # print("Making RGB grain, width: %d, height: %d, saturation: %s, grain-size: %s, power: %s, seed: %d" % (
-            # noise_width, noise_height, str(saturation), str(grain_size), str(power), seed))
+        print("Making RGB grain, width: %d, height: %d, saturation: %s, grain-size: %s, power: %s, seed: %d" % (
+            noise_width, noise_height, str(saturation), str(grain_size), str(power), seed))
         img = _makeRgbNoise(noise_width, noise_height, power, saturation, seed)
 
     # Resample

--- a/nodes.py
+++ b/nodes.py
@@ -195,7 +195,7 @@ class ProPostFilmGrain:
             tensor_image = image[b].numpy()
 
             # Apply vignette
-            vignette_image = self.apply_filmgrain(tensor_image, gray_scale, grain_type_index, grain_sat, grain_power, shadows, highs, scale, sharpen, src_gamma, seed+b)
+            vignette_image = self.apply_filmgrain(tensor_image, gray_scale, grain_type_index, grain_sat, grain_power, shadows, highs, scale, sharpen, src_gamma, seed+(b*10))
 
             tensor = torch.from_numpy(vignette_image).unsqueeze(0)
             result[b] = tensor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy
+numpy<2.0
 Pillow
 opencv-python
 colour-science
+pyfastnoisesimd


### PR DESCRIPTION
Uses `pyfastnoisesimd` to get over a 2x performance increase. Can test using:

## Color Noise
```bash
python3 graingen.py output_image.png 800 600 2 30 1 42
```

ORIG: 0.21383213996887207
SIMD: 0.08792400360107422

## Mono Noise
```bash
python3 graingen.py output_image.png 800 600 2 30 -1 42
```

ORIG: 0.06670999526977539
SIMD: 0.029595136642456055