### PR TITLE
fix `redefined-outer-name`

### DIFF
--- a/filmgrainer/graingen.py
+++ b/filmgrainer/graingen.py
@@ -2,48 +2,48 @@ from PIL import Image
 import random
 import numpy as np
 
-def _makeGrayNoise(width, height, power):
-    buffer = np.zeros([height, width], dtype=int)
+def _makeGrayNoise(width_value, height_value, power_value):
+    buffer = np.zeros([height_value, width_value], dtype=int)
 
-    for y in range(0, height):
-        for x in range(0, width):
-            buffer[y, x] = random.gauss(128, power)
+    for y in range(0, height_value):
+        for x in range(0, width_value):
+            buffer[y, x] = random.gauss(128, power_value)
     buffer = buffer.clip(0, 255)
     return Image.fromarray(buffer.astype(dtype=np.uint8))
 
-def _makeRgbNoise(width, height, power, saturation):
-    buffer = np.zeros([height, width, 3], dtype=int)
-    intens_power = power * (1.0 - saturation)
-    for y in range(0, height):
-        for x in range(0, width):
+def _makeRgbNoise(width_param, height_param, noise_power, saturation):
+    buffer = np.zeros([height_param, width_param, 3], dtype=int)
+    intens_power = noise_power * (1.0 - saturation)
+    for y in range(0, height_param):
+        for x in range(0, width_param):
             intens = random.gauss(128, intens_power)
-            buffer[y, x, 0] = random.gauss(0, power) * saturation + intens
-            buffer[y, x, 1] = random.gauss(0, power) * saturation + intens
-            buffer[y, x, 2] = random.gauss(0, power) * saturation + intens
+            buffer[y, x, 0] = random.gauss(0, noise_power) * saturation + intens
+            buffer[y, x, 1] = random.gauss(0, noise_power) * saturation + intens
+            buffer[y, x, 2] = random.gauss(0, noise_power) * saturation + intens
 
     buffer = buffer.clip(0, 255)
     return Image.fromarray(buffer.astype(dtype=np.uint8))
 
 
-def grainGen(width, height, grain_size, power, saturation, seed = 1):
+def grainGen(width_param, grain_height, grain_size_param, power_value, saturation, seed_value=1):
     # A grain_size of 1 means the noise buffer will be made 1:1
     # A grain_size of 2 means the noise buffer will be resampled 1:2
-    noise_width = int(width / grain_size)
-    noise_height = int(height / grain_size)
-    random.seed(seed)
+    noise_width = int(width_param / grain_size_param)
+    noise_height = int(grain_height / grain_size_param)
+    random.seed(seed_value)
 
     if saturation < 0.0:
         print("Making B/W grain, width: %d, height: %d, grain-size: %s, power: %s, seed: %d" % (
-            noise_width, noise_height, str(grain_size), str(power), seed))
-        img = _makeGrayNoise(noise_width, noise_height, power)
+            noise_width, noise_height, str(grain_size_param), str(power_value), seed_value))
+        img = _makeGrayNoise(noise_width, noise_height, power_value)
     else:
         print("Making RGB grain, width: %d, height: %d, saturation: %s, grain-size: %s, power: %s, seed: %d" % (
-            noise_width, noise_height, str(saturation), str(grain_size), str(power), seed))
-        img = _makeRgbNoise(noise_width, noise_height, power, saturation)
+            noise_width, noise_height, str(saturation), str(grain_size_param), str(power_value), seed_value))
+        img = _makeRgbNoise(noise_width, noise_height, power_value, saturation)
 
     # Resample
-    if grain_size != 1.0:
-        img = img.resize((width, height), resample = Image.LANCZOS)
+    if grain_size_param != 1.0:
+        img = img.resize((width_param, grain_height), resample=Image.LANCZOS)
 
     return img
 


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `redefined-outer-name`.
"Used when a variable's name hides a name defined in an outer scope or except handler."

Note:
This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.