### PR TITLE
feat: Add focal_range and mask_blur parameters to depthblur_image

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ This filter allows you to blur the image based on a depth map. You can use this 
 | focal_depth          | `1.0`     | Float   | The focal depth of the blur. `1.0` is the closest, `0.0` is the farthest.      |
 | focus_spread         | `1.0`     | Float   | The spread of the area of focus. A larger value makes more of the image sharp. |
 | steps                | `5`       | Integer | The number of steps to use when blurring the image. Higher numbers are slower. |
-
+| focal_range          | `0.0`     | Float   | `1.0` means all areas clear, `0.0` means only focal point is clear.            |
+| mask_blur            | `1`       | Integer | Mask blur strength (1 to 127).`1` means no blurring.                           |
 
 ### Apply LUT
 

--- a/nodes.py
+++ b/nodes.py
@@ -337,35 +337,65 @@ class ProPostDepthMapBlur:
                     "min": 1,
                     "max": 32,
                 }),
+                "focal_range": ("FLOAT", {
+                    "default": 0.0,
+                    "min": 0.0,
+                    "max": 1.0,
+                    "step": 0.01
+                }),
+                "mask_blur": ("INT", {
+                    "default": 1,
+                    "min": 1,
+                    "max": 127,
+                    "step": 2
+                }),
             },
         }
  
-    RETURN_TYPES = ("IMAGE",)
+    RETURN_TYPES = ("IMAGE","MASK")
     RETURN_NAMES = ()
  
     FUNCTION = "depthblur_image"
- 
+    DESCRIPTION = """
+    blur_strength: 表示模糊强度。这个参数控制模糊效果的总体强度，值越大，图像的模糊程度越高。
+    focal_depth: 表示焦点深度。这个参数用于确定图像中的哪个深度层次应该保持清晰，而其他层次则根据深度差异进行模糊处理。
+    focus_spread: 表示焦点扩散范围。这个参数控制在焦点深度附近的模糊过渡区域的大小，值越大，过渡区域越宽，模糊效果在焦点附近的扩散也就越平滑。
+    steps: 表示模糊处理的步骤数。这个参数决定了模糊效果的计算精度，步骤数越多，模糊效果越精细，但同时计算量也会增加。
+    focal_range: 表示焦点范围。这个参数用于调整焦点深度内保持清晰的深度范围，值越大，焦点深度附近保持清晰的区域越宽。
+    mask_blur: 表示用于模糊深度图的掩码模糊强度。这个参数控制深度图模糊处理的强度，用于在计算最终的模糊效果前，对深度图进行预处理，以实现更自然的模糊过渡效果。
+    
+    blur_strength: Represents the blur strength. This parameter controls the overall intensity of the blur effect; the higher the value, the more blurred the image becomes.
+    focal_depth: Represents the focal depth. This parameter is used to determine which depth level in the image should remain sharp, while other levels are blurred based on depth differences.
+    focus_spread: Represents the focus spread range. This parameter controls the size of the blur transition area near the focal depth; the larger the value, the wider the transition area, and the smoother the blur effect spreads around the focus.
+    steps: Represents the number of steps in the blur process. This parameter determines the calculation precision of the blur effect; the more steps, the finer the blur effect, but this also increases the computational load.
+    focal_range: Represents the focal range. This parameter is used to adjust the depth range within the focal depth that remains sharp; the larger the value, the wider the area around the focal depth that remains sharp.
+    mask_blur: Represents the mask blur strength for blurring the depth map. This parameter controls the intensity of the depth map's blur treatment, used for preprocessing the depth map before calculating the final blur effect, to achieve a more natural blur transition.
+    """
     #OUTPUT_NODE = False
  
     CATEGORY = "Pro Post/Blur Effects"
  
-    def depthblur_image(self, image: torch.Tensor, depth_map: torch.Tensor, blur_strength: float, focal_depth: float, focus_spread:float, steps: int):
+    def depthblur_image(self, image: torch.Tensor, depth_map: torch.Tensor, blur_strength: float, focal_depth: float, focus_spread:float, steps: int, focal_range: float, mask_blur: int):
         batch_size, height, width, _ = image.shape
-        result = torch.zeros_like(image)
+        image_result = torch.zeros_like(image)
+        mask_result = torch.zeros((batch_size, height, width), dtype=torch.float32)
 
         for b in range(batch_size):
             tensor_image = image[b].numpy()
             tensor_image_depth = depth_map[b].numpy()
 
             # Apply blur
-            blur_image = self.apply_depthblur(tensor_image, tensor_image_depth, blur_strength, focal_depth, focus_spread, steps)
+            blur_image,depth_mask = self.apply_depthblur(tensor_image, tensor_image_depth, blur_strength, focal_depth, focus_spread, steps, focal_range, mask_blur)
 
-            tensor = torch.from_numpy(blur_image).unsqueeze(0)
-            result[b] = tensor
+            tensor_image = torch.from_numpy(blur_image).unsqueeze(0)
+            tensor_mask = torch.from_numpy(depth_mask).unsqueeze(0)
 
-        return (result,)
+            image_result[b] = tensor_image
+            mask_result[b] = tensor_mask
 
-    def apply_depthblur(self, image, depth_map, blur_strength, focal_depth, focus_spread, steps):
+        return (image_result,mask_result)
+
+    def apply_depthblur(self, image, depth_map, blur_strength, focal_depth, focus_spread, steps, focal_range, mask_blur):
         # Normalize the input image if needed
         needs_normalization = image.max() > 1
         if needs_normalization:
@@ -383,6 +413,13 @@ class ProPostDepthMapBlur:
         depth_mask = np.abs(depth_map_resized - focal_depth)
         depth_mask = np.clip(depth_mask / np.max(depth_mask), 0, 1)
 
+        # Process the depth_mask
+        depth_mask[depth_mask < focal_range] = 0
+        depth_mask[depth_mask >= focal_range] = (depth_mask[depth_mask >= focal_range] - focal_range) / (1 - focal_range)
+
+        # Apply mask blur
+        depth_mask = cv2.GaussianBlur(depth_mask, (mask_blur, mask_blur), 0)
+
         # Generate blurred versions of the image
         blurred_images = processing_utils.generate_blurred_images(image, blur_strength, steps, focus_spread)
 
@@ -393,7 +430,7 @@ class ProPostDepthMapBlur:
         if needs_normalization:
             final_image = np.clip(final_image * 255, 0, 255).astype(np.uint8)
 
-        return final_image
+        return final_image, depth_mask
 
 
 class ProPostApplyLUT:

--- a/nodes.py
+++ b/nodes.py
@@ -357,18 +357,16 @@ class ProPostDepthMapBlur:
  
     FUNCTION = "depthblur_image"
     DESCRIPTION = """
-    blur_strength: 表示模糊强度。这个参数控制模糊效果的总体强度，值越大，图像的模糊程度越高。
-    focal_depth: 表示焦点深度。这个参数用于确定图像中的哪个深度层次应该保持清晰，而其他层次则根据深度差异进行模糊处理。
-    focus_spread: 表示焦点扩散范围。这个参数控制在焦点深度附近的模糊过渡区域的大小，值越大，过渡区域越宽，模糊效果在焦点附近的扩散也就越平滑。
-    steps: 表示模糊处理的步骤数。这个参数决定了模糊效果的计算精度，步骤数越多，模糊效果越精细，但同时计算量也会增加。
-    focal_range: 表示焦点范围。这个参数用于调整焦点深度内保持清晰的深度范围，值越大，焦点深度附近保持清晰的区域越宽。
-    mask_blur: 表示用于模糊深度图的掩码模糊强度。这个参数控制深度图模糊处理的强度，用于在计算最终的模糊效果前，对深度图进行预处理，以实现更自然的模糊过渡效果。
-    
     blur_strength: Represents the blur strength. This parameter controls the overall intensity of the blur effect; the higher the value, the more blurred the image becomes.
+
     focal_depth: Represents the focal depth. This parameter is used to determine which depth level in the image should remain sharp, while other levels are blurred based on depth differences.
+
     focus_spread: Represents the focus spread range. This parameter controls the size of the blur transition area near the focal depth; the larger the value, the wider the transition area, and the smoother the blur effect spreads around the focus.
+
     steps: Represents the number of steps in the blur process. This parameter determines the calculation precision of the blur effect; the more steps, the finer the blur effect, but this also increases the computational load.
+
     focal_range: Represents the focal range. This parameter is used to adjust the depth range within the focal depth that remains sharp; the larger the value, the wider the area around the focal depth that remains sharp.
+    
     mask_blur: Represents the mask blur strength for blurring the depth map. This parameter controls the intensity of the depth map's blur treatment, used for preprocessing the depth map before calculating the final blur effect, to achieve a more natural blur transition.
     """
     #OUTPUT_NODE = False


### PR DESCRIPTION
This commit adds two new parameters, "focal_range" and "mask_blur", to the "depthblur_image" function in the "ProPostDepthMapBlur" class. The "focal_range" parameter adjusts the depth range within the focal depth that remains sharp, while the "mask_blur" parameter controls the intensity of the depth map's blur treatment. These additions provide more control over the blur effect and allow for more natural blur transitions.

In addition, I export the processed depth mask additionally in order to use this mask for other processing, such as inpaint